### PR TITLE
test(e2e): add network wait helpers to eliminate timeouts

### DIFF
--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { waitForPlannerOK } from './utils/waits';
 
 test.describe('Traveling App', () => {
   test.beforeEach(async ({ page }) => {
@@ -76,9 +77,11 @@ test.describe('Traveling App', () => {
     
     // Should show loading state
     await expect(page.locator('#generateTripBtn')).toContainText('Generating');
-    
+
+    // Wait for planner API to respond
+    await waitForPlannerOK(page);
+
     // Trip should be generated
-    await page.waitForTimeout(2000);
     await expect(page.locator('#enhancedTripDisplay')).not.toHaveAttribute('hidden');
   });
 

--- a/tests/e2e/utils/waits.ts
+++ b/tests/e2e/utils/waits.ts
@@ -1,0 +1,41 @@
+import { Page } from '@playwright/test';
+
+/**
+ * Wait for the planner API to respond before asserting DOM.
+ * Prevents timeouts on planner tests by waiting for network response.
+ *
+ * @param page - Playwright Page object
+ * @param timeout - Maximum wait time in milliseconds (default: 40000ms)
+ */
+export async function waitForPlannerOK(page: Page, timeout = 40_000): Promise<void> {
+  await page.waitForResponse(
+    (response) => {
+      return response.url().includes('/planner/plan-day') && response.status() === 200;
+    },
+    { timeout }
+  );
+}
+
+/**
+ * Wait for any API response matching a given URL pattern.
+ *
+ * @param page - Playwright Page object
+ * @param urlPattern - URL pattern to match (can be string or regex)
+ * @param timeout - Maximum wait time in milliseconds (default: 40000ms)
+ */
+export async function waitForApiResponse(
+  page: Page,
+  urlPattern: string | RegExp,
+  timeout = 40_000
+): Promise<void> {
+  await page.waitForResponse(
+    (response) => {
+      const url = response.url();
+      if (typeof urlPattern === 'string') {
+        return url.includes(urlPattern) && response.status() === 200;
+      }
+      return urlPattern.test(url) && response.status() === 200;
+    },
+    { timeout }
+  );
+}


### PR DESCRIPTION
## Changes

This PR adds network wait helpers to prevent ~30s timeouts on planner E2E tests by waiting for actual API responses instead of using arbitrary delays.

### Key Changes

1. **tests/e2e/utils/waits.ts** (NEW)
   - `waitForPlannerOK()` - Waits for `/planner/plan-day` API response
   - `waitForApiResponse()` - Generic helper for any API endpoint
   - 40s timeout for API responses (increased from default 30s)

2. **tests/e2e/app.spec.ts**
   - Import `waitForPlannerOK` helper
   - Replace `waitForTimeout(2000)` with network-aware wait
   - Wait for actual planner API response before asserting DOM

### Before
```typescript
// Brittle: waits fixed 2s regardless of API response time
await page.waitForTimeout(2000);
await expect(page.locator('#enhancedTripDisplay')).not.toHaveAttribute('hidden');
```

### After
```typescript
// Robust: waits for actual API response, up to 40s
await waitForPlannerOK(page);
await expect(page.locator('#enhancedTripDisplay')).not.toHaveAttribute('hidden');
```

### Benefits

- ✅ Eliminates ~30.1s timeout failures on planner tests
- ✅ Tests complete faster when API responds quickly
- ✅ More reliable - waits for actual network activity
- ✅ Reusable helpers for other API-dependent tests

### Related

Part of E2E testing infrastructure improvements (Step TEST-STABILIZE).

🤖 Generated with [Claude Code](https://claude.ai/code)